### PR TITLE
Add isTechnicalRoleAlias to EmailAddress

### DIFF
--- a/src/EmailAddress.php
+++ b/src/EmailAddress.php
@@ -7,7 +7,7 @@ use InvalidArgumentException;
 class EmailAddress
 {
     /**
-     * Standard email aliases for email watchdogs.
+     * Standard email aliases that could potentially be reported to email watchdogs.
      */
     const DISALLOWED_STANDARD_EMAIL_ALIASES = [
         'postmaster',

--- a/src/EmailAddress.php
+++ b/src/EmailAddress.php
@@ -6,13 +6,11 @@ use InvalidArgumentException;
 
 class EmailAddress
 {
-    /**
-     * Standard email aliases that could potentially be reported to email watchdogs.
-     */
-    const DISALLOWED_STANDARD_EMAIL_ALIASES = [
-        'postmaster',
+    const TECHNICAL_ROLE_ALIASES = [
         'abuse',
         'noc',
+        'security',
+        'postmaster',
     ];
 
     /**
@@ -82,7 +80,7 @@ class EmailAddress
      * Indicates whether the specified email address equals this email address.
      *
      * @param EmailAddress|null $other
-     * @param bool              $caseInsensitive Whether to compare addresses in a case-insensitive manner. Defaults to
+     * @param bool $caseInsensitive Whether to compare addresses in a case-insensitive manner. Defaults to
      *                                           false.
      *
      * @return bool
@@ -105,20 +103,20 @@ class EmailAddress
     }
 
     /**
-     * Returns true if the email contains one of our defined disallowed aliases.
+     * Returns true if the email contains a standard role alias.
      *
      * @return bool
      */
-    public function hasDisallowedAlias(): bool
+    public function isTechnicalRoleAlias(): bool
     {
-        return in_array($this->localPart(), self::DISALLOWED_STANDARD_EMAIL_ALIASES);
+        return in_array(strtolower($this->localPart()), self::TECHNICAL_ROLE_ALIASES, true);
     }
 
     /**
      * Attempts to parse the specified email address.
      *
-     * @param string       $emailAddressString The email address string to try parsing.
-     * @param EmailAddress $emailAddress       The variable to assign the email address to.
+     * @param string $emailAddressString The email address string to try parsing.
+     * @param EmailAddress $emailAddress The variable to assign the email address to.
      *
      * @return bool Whether the specified email address could be parsed.
      */

--- a/src/EmailAddress.php
+++ b/src/EmailAddress.php
@@ -80,7 +80,7 @@ class EmailAddress
      * Indicates whether the specified email address equals this email address.
      *
      * @param EmailAddress|null $other
-     * @param bool $caseInsensitive Whether to compare addresses in a case-insensitive manner. Defaults to
+     * @param bool              $caseInsensitive Whether to compare addresses in a case-insensitive manner. Defaults to
      *                                           false.
      *
      * @return bool
@@ -115,7 +115,7 @@ class EmailAddress
     /**
      * Attempts to parse the specified email address.
      *
-     * @param string $emailAddressString The email address string to try parsing.
+     * @param string       $emailAddressString The email address string to try parsing.
      * @param EmailAddress $emailAddress The variable to assign the email address to.
      *
      * @return bool Whether the specified email address could be parsed.

--- a/src/EmailAddress.php
+++ b/src/EmailAddress.php
@@ -116,7 +116,7 @@ class EmailAddress
      * Attempts to parse the specified email address.
      *
      * @param string       $emailAddressString The email address string to try parsing.
-     * @param EmailAddress $emailAddress The variable to assign the email address to.
+     * @param EmailAddress $emailAddress       The variable to assign the email address to.
      *
      * @return bool Whether the specified email address could be parsed.
      */

--- a/src/EmailAddress.php
+++ b/src/EmailAddress.php
@@ -7,6 +7,15 @@ use InvalidArgumentException;
 class EmailAddress
 {
     /**
+     * Standard email aliases for email watchdogs.
+     */
+    const DISALLOWED_STANDARD_EMAIL_ALIASES = [
+        'postmaster',
+        'abuse',
+        'noc',
+    ];
+
+    /**
      * @var string The email address string.
      */
     private $emailAddress;
@@ -93,6 +102,16 @@ class EmailAddress
         } else {
             return $this->emailAddress === $other->emailAddress;
         }
+    }
+
+    /**
+     * Returns true if the email contains one of our defined disallowed aliases.
+     *
+     * @return bool
+     */
+    public function hasDisallowedAlias(): bool
+    {
+        return in_array($this->localPart(), self::DISALLOWED_STANDARD_EMAIL_ALIASES);
     }
 
     /**

--- a/tests/EmailAddressTest.php
+++ b/tests/EmailAddressTest.php
@@ -44,7 +44,7 @@ class EmailAddressTest extends TestCase
 
     /**
      * @param EmailAddress $emailAddress
-     * @param string $localPart
+     * @param string       $localPart
      *
      * @dataProvider validEmailAddressesWithParts
      */
@@ -55,8 +55,8 @@ class EmailAddressTest extends TestCase
 
     /**
      * @param EmailAddress $emailAddress
-     * @param string $localPart
-     * @param string $domainPart
+     * @param string       $localPart
+     * @param string       $domainPart
      *
      * @dataProvider validEmailAddressesWithParts
      */
@@ -66,10 +66,10 @@ class EmailAddressTest extends TestCase
     }
 
     /**
-     * @param EmailAddress $first
+     * @param EmailAddress      $first
      * @param EmailAddress|null $second
-     * @param bool $shouldEqual
-     * @param bool $caseInsensitive
+     * @param bool              $shouldEqual
+     * @param bool              $caseInsensitive
      *
      * @dataProvider equalityTestEmailAddresses
      */
@@ -84,7 +84,7 @@ class EmailAddressTest extends TestCase
 
     /**
      * @param EmailAddress $emailAddress
-     * @param bool $expectedResult
+     * @param bool         $expectedResult
      *
      * @dataProvider hasTechnicalRoleAliasDataProvider
      */

--- a/tests/EmailAddressTest.php
+++ b/tests/EmailAddressTest.php
@@ -83,6 +83,17 @@ class EmailAddressTest extends TestCase
     }
 
     /**
+     * @param EmailAddress $emailAddress
+     * @param bool         $expectedResult
+     *
+     * @dataProvider hasDisallowedAliasDataProvider
+     */
+    public function testHasDisallowedAlias(EmailAddress $emailAddress, bool $expectedResult)
+    {
+        $this->assertEquals($emailAddress->hasDisallowedAlias(), $expectedResult);
+    }
+
+    /**
      * @return string[][]
      */
     public function invalidEmailAddressStrings(): array
@@ -138,6 +149,20 @@ class EmailAddressTest extends TestCase
             [new EmailAddress('fake@example.com'), 'string', false],
             [new EmailAddress('fake@example.com'), new EmailAddress('Fake@example.com'), false],
             [new EmailAddress('fake@example.com'), new EmailAddress('FAKE@example.com'), true, true],
+        ];
+    }
+
+    /**
+     * @return mixed[][]
+     */
+    public function hasDisallowedAliasDataProvider(): array
+    {
+        return [
+            [new EmailAddress('fake@example.com'), false],
+            [new EmailAddress('postmaster@example.com'), true],
+            [new EmailAddress('abuse@example.com'), true],
+            [new EmailAddress('noc@example.com'), true],
+
         ];
     }
 }

--- a/tests/EmailAddressTest.php
+++ b/tests/EmailAddressTest.php
@@ -44,7 +44,7 @@ class EmailAddressTest extends TestCase
 
     /**
      * @param EmailAddress $emailAddress
-     * @param string       $localPart
+     * @param string $localPart
      *
      * @dataProvider validEmailAddressesWithParts
      */
@@ -55,8 +55,8 @@ class EmailAddressTest extends TestCase
 
     /**
      * @param EmailAddress $emailAddress
-     * @param string       $localPart
-     * @param string       $domainPart
+     * @param string $localPart
+     * @param string $domainPart
      *
      * @dataProvider validEmailAddressesWithParts
      */
@@ -66,10 +66,10 @@ class EmailAddressTest extends TestCase
     }
 
     /**
-     * @param EmailAddress      $first
+     * @param EmailAddress $first
      * @param EmailAddress|null $second
-     * @param bool              $shouldEqual
-     * @param bool              $caseInsensitive
+     * @param bool $shouldEqual
+     * @param bool $caseInsensitive
      *
      * @dataProvider equalityTestEmailAddresses
      */
@@ -84,13 +84,13 @@ class EmailAddressTest extends TestCase
 
     /**
      * @param EmailAddress $emailAddress
-     * @param bool         $expectedResult
+     * @param bool $expectedResult
      *
-     * @dataProvider hasDisallowedAliasDataProvider
+     * @dataProvider hasTechnicalRoleAliasDataProvider
      */
-    public function testHasDisallowedAlias(EmailAddress $emailAddress, bool $expectedResult)
+    public function testHasTechnicalRoleAlias(EmailAddress $emailAddress, bool $expectedResult)
     {
-        $this->assertEquals($emailAddress->hasDisallowedAlias(), $expectedResult);
+        $this->assertEquals($emailAddress->isTechnicalRoleAlias(), $expectedResult);
     }
 
     /**
@@ -155,14 +155,29 @@ class EmailAddressTest extends TestCase
     /**
      * @return mixed[][]
      */
-    public function hasDisallowedAliasDataProvider(): array
+    public function hasTechnicalRoleAliasDataProvider(): array
     {
         return [
+            // Non technical roles
             [new EmailAddress('fake@example.com'), false],
-            [new EmailAddress('postmaster@example.com'), true],
+            [new EmailAddress('info@example.com'), false],
+            [new EmailAddress('marketing@example.com'), false],
+            [new EmailAddress('sales@example.com'), false],
+            [new EmailAddress('support@example.com'), false],
+            [new EmailAddress('hostmaster@example.com'), false],
+            [new EmailAddress('usenet@example.com'), false],
+            [new EmailAddress('news@example.com'), false],
+            [new EmailAddress('webmaster@example.com'), false],
+            [new EmailAddress('www@example.com'), false],
+            [new EmailAddress('uucp@example.com'), false],
+            [new EmailAddress('ftp@example.com'), false],
+            // Technical roles
             [new EmailAddress('abuse@example.com'), true],
             [new EmailAddress('noc@example.com'), true],
-
+            [new EmailAddress('security@example.com'), true],
+            [new EmailAddress('postmaster@example.com'), true],
+            // Test uppercase values.
+            [new EmailAddress('FTP@example.com'), true],
         ];
     }
 }

--- a/tests/EmailAddressTest.php
+++ b/tests/EmailAddressTest.php
@@ -177,7 +177,7 @@ class EmailAddressTest extends TestCase
             [new EmailAddress('security@example.com'), true],
             [new EmailAddress('postmaster@example.com'), true],
             // Test uppercase values.
-            [new EmailAddress('FTP@example.com'), true],
+            [new EmailAddress('PostMaster@example.com'), true],
         ];
     }
 }


### PR DESCRIPTION
This function will allow us to check for what we consider disallowed aliases that might be reported to watch dogs.