### PR TITLE
Add General Interface for Contact Methods

### DIFF
--- a/src/ContactMethodInterface.php
+++ b/src/ContactMethodInterface.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Pinnacle\CommonValueObjects;
+
+interface ContactMethodInterface
+{
+    public function value(): string;
+}

--- a/src/EmailAddress.php
+++ b/src/EmailAddress.php
@@ -4,7 +4,7 @@ namespace Pinnacle\CommonValueObjects;
 
 use InvalidArgumentException;
 
-class EmailAddress
+class EmailAddress implements ContactMethodInterface
 {
     const TECHNICAL_ROLE_ALIASES = [
         'abuse',

--- a/src/PhoneNumber.php
+++ b/src/PhoneNumber.php
@@ -21,7 +21,7 @@ class PhoneNumber implements ContactMethodInterface
      *
      * @throws InvalidArgumentException If the phone number is not a valid North American phone number.
      */
-    public function __construct(string $phoneNumber)
+    public function __construct($phoneNumber)
     {
         $normalizedPhoneNumber = self::parseNorthAmericanPhoneNumber($phoneNumber);
         if ($normalizedPhoneNumber === null) {

--- a/src/PhoneNumber.php
+++ b/src/PhoneNumber.php
@@ -7,7 +7,7 @@ use InvalidArgumentException;
 /**
  * Value object for a North American phone number.
  */
-class PhoneNumber
+class PhoneNumber implements ContactMethodInterface
 {
     /**
      * @var string The phone number in format 1XXXYYYZZZZ xNNNNNN.
@@ -21,7 +21,7 @@ class PhoneNumber
      *
      * @throws InvalidArgumentException If the phone number is not a valid North American phone number.
      */
-    public function __construct($phoneNumber)
+    public function __construct(string $phoneNumber)
     {
         $normalizedPhoneNumber = self::parseNorthAmericanPhoneNumber($phoneNumber);
         if ($normalizedPhoneNumber === null) {
@@ -47,6 +47,11 @@ class PhoneNumber
     public function __toString()
     {
         return $this->format();
+    }
+
+    public function value(): string
+    {
+        return $this->normalized();
     }
 
     /**

--- a/src/SmsPhoneNumber.php
+++ b/src/SmsPhoneNumber.php
@@ -5,7 +5,7 @@ namespace Pinnacle\CommonValueObjects;
 use InvalidArgumentException;
 use UnexpectedValueException;
 
-class SmsPhoneNumber
+class SmsPhoneNumber implements ContactMethodInterface
 {
     /**
      * @var PhoneNumber|null If this is a standard NANPA number, this will contain the phone number.
@@ -63,6 +63,11 @@ class SmsPhoneNumber
     public function __toString(): string
     {
         return $this->format();
+    }
+
+    public function value(): string
+    {
+        return $this->normalized();
     }
 
     /**


### PR DESCRIPTION
This adds a ContactMethodInterface for the phone number, email address, and sms phone number classes. So that if we have an instance that could be any of the three, we can call `->value()` on them in order to get their pure string value.